### PR TITLE
chore: add JetBrains IDE config directory .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 /build
 /dist
 /coverage.xml
+/.idea


### PR DESCRIPTION
JetBrains PyCharm is a common IDE for Python development.

Adding the configuration directory to the `.gitignore` is a common pattern and avoids unexpected local config commits.