### PR TITLE
chore: add editorconfig to set python indent style to tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+
+[*.py]
+indent_style = tab


### PR DESCRIPTION
As the python files are currently using tab ident style, an `.editorconfig` would be helpful, to set the IDE or editor ident settings to tab, instead of 4 spaces.